### PR TITLE
Remove luaPackages argument for awesome-git

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,7 +112,6 @@
             + old.GI_TYPELIB_PATH;
           })).override {
             stdenv = clangStdenv;
-            luaPackages = pkgs.lua52Packages;
             gtk3Support = true;
           };
 


### PR DESCRIPTION
`luaPackages` DNE so it doesn't need to be overridden, if my logic is correct.

I did test this and `awesome-git` does get built.