### PR TITLE
Fix AWM Cmake 4 build

### DIFF
--- a/overlays/window-managers.nix
+++ b/overlays/window-managers.nix
@@ -13,13 +13,7 @@
           __output = {
             src.__assign = package.src;
             version.__assign = package.version;
-
-            patches.__assign = [
-              (pkgs.fetchpatch2 {
-                url = "https://patch-diff.githubusercontent.com/raw/awesomeWM/awesome/pull/4030.patch";
-                hash = "sha256-vidbg6f79f8aK8fjHoXe29PB4E4MyCyCA3Fq/tervlA=";
-              })
-            ];
+            patches.__assign = [ ];
 
             cmakeFlags.__append = [ "-DGENERATE_MANPAGES=OFF" ];
 


### PR DESCRIPTION
The original PR https://github.com/awesomeWM/awesome/pull/4030 mentions that cmake 4 support is fixed in master, so the patch shouldn't be needed at all. I tested and it does build on Linux.

Removing the substituteInPlace still causes it to fail so I left that in